### PR TITLE
Fix DistributedSampler mem usage on large datasets

### DIFF
--- a/torch/utils/data/distributed.py
+++ b/torch/utils/data/distributed.py
@@ -76,17 +76,8 @@ class DistributedSampler(Sampler[T_co]):
         self.rank = rank
         self.epoch = 0
         self.drop_last = drop_last
-        # If the dataset length is evenly divisible by # of replicas, then there
-        # is no need to drop any data, since the dataset will be split equally.
-        if self.drop_last and len(self.dataset) % self.num_replicas != 0:  # type: ignore
-            # Split to nearest available length that is evenly divisible.
-            # This is to ensure each rank receives the same amount of data when
-            # using this Sampler.
-            self.num_samples = math.ceil(
-                # `type:ignore` is required because Dataset cannot provide a default __len__
-                # see NOTE in pytorch/torch/utils/data/sampler.py
-                (len(self.dataset) - self.num_replicas) / self.num_replicas  # type: ignore
-            )
+        if self.drop_last:
+            self.num_samples = len(self.dataset) // self.num_replicas  # type: ignore
         else:
             self.num_samples = math.ceil(len(self.dataset) / self.num_replicas)  # type: ignore
         self.total_size = self.num_samples * self.num_replicas
@@ -98,27 +89,24 @@ class DistributedSampler(Sampler[T_co]):
             # deterministically shuffle based on epoch and seed
             g = torch.Generator()
             g.manual_seed(self.seed + self.epoch)
-            indices = torch.randperm(len(self.dataset), generator=g).tolist()  # type: ignore
+            indices = torch.randperm(len(self.dataset), generator=g)  # type: ignore
         else:
-            indices = list(range(len(self.dataset)))  # type: ignore
+            indices = torch.arange(len(self.dataset))  # type: ignore
+
+        offset = 0
+        while (offset + self.num_replicas) <= len(indices):
+            yield indices[offset + self.rank].item()
+            offset += self.num_replicas
 
         if not self.drop_last:
-            # add extra samples to make it evenly divisible
-            padding_size = self.total_size - len(indices)
-            if padding_size <= len(indices):
-                indices += indices[:padding_size]
-            else:
-                indices += (indices * math.ceil(padding_size / len(indices)))[:padding_size]
-        else:
-            # remove tail of data to make it evenly divisible.
-            indices = indices[:self.total_size]
-        assert len(indices) == self.total_size
-
-        # subsample
-        indices = indices[self.rank:self.total_size:self.num_replicas]
-        assert len(indices) == self.num_samples
-
-        return iter(indices)
+            # find the number of samples remaining
+            num_rem = len(indices) % self.num_replicas
+            if num_rem:
+                if self.rank < num_rem:
+                    yield indices[offset + self.rank].item()
+                else:
+                    # wraparound, but mod in the case of self.rank >= len(indices)
+                    yield indices[self.rank % len(indices)].item()
 
     def __len__(self) -> int:
         return self.num_samples


### PR DESCRIPTION
The current implementation of DistributedSampler generates a python list to hold all of the indices, and then returns a slice of this list for the given rank (creating a partial copy of the list). When the underlying dataset is large, both of these choices waste a large amount of memory. It is much more efficient to create a tensor to hold the indices, and then index into that tensor instead of creating slices.

In the case of a sampler with `shuffle=False`, it would be possible to avoid creating the `indices` tensor entirely (since the index will always match the value), but I have opted instead here to keep the implementation as similar to the existing version as possible. One possible benefit of this approach is that memory usage will not significantly change based on changing this parameter. Still, it might be better to simply return the indices directly without the underlying array.

Additionally, the logic around calculating the number of samples is unnecessarily complex. When `drop_last=True`, this can be calculated with floor division.

In a simple test script which creates a sampler for a dataset with a 100,000,000 items, memory usage is reduced 98% compared to the existing implementation.

Fixes #{45427}
